### PR TITLE
update paths to badges/buckler

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,1 +1,1 @@
-github.com/gittip/img.shields.io
+github.com/badges/buckler

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ⛨ Buckler ⛨
 
-[![Build Status](https://travis-ci.org/gittip/img.shields.io.png)](https://travis-ci.org/gittip/img.shields.io)
+[![Build Status](https://travis-ci.org/badges/buckler.png)](https://travis-ci.org/badges/buckler)
 [![Buckler Shield](http://b.repl.ca/v1/use-buckler-blue.png)](http://buckler.repl.ca)
 [![Get Hype](http://b.repl.ca/v1/GET-HYPE!-orange.png)](http://buckler.repl.ca)
 [![MIT License](http://b.repl.ca/v1/License-MIT-red.png)](LICENSE)
 [![CLI interface](http://b.repl.ca/v1/command-line-blue.png)](#command-line)
 
-Buckler is [Shields](https://github.com/olivierlacan/shields) as a Service (ShaaS, or alternatively, Badges as a Service)
+Buckler is [Shields](https://github.com/badges/shields) as a Service (ShaaS, or alternatively, Badges as a Service)
 for use in GitHub READMEs, or anywhere else. Use buckler with your favorite continuous integration tool, performance
 monitoring service API, or ridiculous in-joke to surface information.
 
@@ -74,7 +74,7 @@ Play around with the simple form on [b.repl.ca](http://b.repl.ca)
 # Installing
 
 ```bash
-go get github.com/gittip/img.shields.io
+go get github.com/badges/buckler
 ```
 
 Alternatively, `git clone` and `go build` to run from source.
@@ -99,5 +99,5 @@ buckler build-passing-brightgreen.png license-MIT-blue.png
 
 # Thanks
 
-- Olivier Lacan for the [shields](https://github.com/olivierlacan/shields) repo
+- Olivier Lacan for the [shields](https://github.com/badges/shields) repo
 - Steve Matteson for [Open Sans](http://opensans.com/)

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func buckle(w http.ResponseWriter, r *http.Request) {
 	makePngShield(w, d)
 }
 
-const basePkg = "github.com/gittip/img.shields.io"
+const basePkg = "github.com/badges/buckler"
 
 func index(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, filepath.Join(staticPath, "index.html"))

--- a/static/index.html
+++ b/static/index.html
@@ -17,8 +17,8 @@
 
 
     <p class="lead">
-      <a href="https://github.com/jbowes/buckler">Buckler</a> is
-      <a href="https://github.com/olivierlacan/shields">Shields</a> as a
+      <a href="https://github.com/badges/buckler">Buckler</a> is
+      <a href="https://github.com/badges/shields">Shields</a> as a
       Service (ShaaS, or alternatively, Badges as a Service) for use in GitHub
       READMEs, or anywhere else. Use buckler with your favorite continuous
       integration tool, performance monitoring service API, or ridiculous
@@ -57,7 +57,7 @@
     <h2>API</h2>
     <hr>
     <p>A full up-to-date description of the API is available in the
-    <a href="https://github.com/jbowes/buckler/blob/master/README.md">README</a>
+    <a href="https://github.com/badges/buckler/blob/master/README.md">README</a>
     on GitHub.
     </p>
   </div> <!-- container -->
@@ -101,7 +101,7 @@
       }
     </script>
 
-    <a href="https://github.com/jbowes/buckler"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/badges/buckler"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
   </body>
 </html>
 


### PR DESCRIPTION
I think the b.repl.ca badges are still broken due to GitHub's caching of non-HTTPS images, but not entirely sure.
