### PR TITLE
Fix setAttribute() call

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -67,11 +67,11 @@
         var c = document.getElementById('c').value;
         var hexInput = document.getElementById('cc');
         if (c === 'custom') {
-          hexInput.setAttribute('required',true);
+          hexInput.setAttribute('required', true);
           hexInput.removeAttribute('disabled');
         } else {
           hexInput.removeAttribute('required');
-          hexInput.setAttribute('disabled',true);
+          hexInput.setAttribute('disabled', true);
         }
       }
       function replace(s) {


### PR DESCRIPTION
element.setAttribute() takes two arguments. Wouldn't work on Chrome/Firefox with only one.
